### PR TITLE
Fix: Remove unnecessary space in Skeleton className

### DIFF
--- a/app/(creatorView)/view/[ipOrgId]/[ipAssetId]/TimeSince.tsx
+++ b/app/(creatorView)/view/[ipOrgId]/[ipAssetId]/TimeSince.tsx
@@ -3,7 +3,7 @@ import { getBlockTimestampFromTransaction } from '@/lib/server/transaction';
 import { Skeleton } from '@/components/ui/skeleton';
 import Icons from '@/components/ui/icons';
 
-export const Fallback = () => <Skeleton className=" w-48 h-6" />;
+export const Fallback = () => <Skeleton className="w-48 h-6" />;
 
 export default async function TimeSince({ txHash }: { txHash: string }) {
   const timestamp = await getBlockTimestampFromTransaction(txHash);


### PR DESCRIPTION
## Description
This PR removes the extra space before `'w-48'` and `'h-6'` in the Skeleton `className` for cleaner styling.

## Test Plan
- 1. Verify that the styling of the Skeleton component is consistent and the extra space has been removed correctly.
- 2. Ensure that no other styling issues appear as a result of this change.

## Related Issue
- Issue #123

## Notes
- No additional changes or special requirements to note.