### PR TITLE
Fix: Remove unnecessary space in Skeleton className

### DIFF
--- a/app/(creatorView)/view/[ipOrgId]/[ipAssetId]/TimeSince.tsx
+++ b/app/(creatorView)/view/[ipOrgId]/[ipAssetId]/TimeSince.tsx
@@ -3,7 +3,7 @@ import { getBlockTimestampFromTransaction } from '@/lib/server/transaction';
 import { Skeleton } from '@/components/ui/skeleton';
 import Icons from '@/components/ui/icons';
 
-export const Fallback = () => <Skeleton className=" w-48 h-6" />;
+export const Fallback = () => <Skeleton className="w-48 h-6" />;
 
 export default async function TimeSince({ txHash }: { txHash: string }) {
   const timestamp = await getBlockTimestampFromTransaction(txHash);


### PR DESCRIPTION
## Description
This PR removes the extra space before 'w-48' and 'h-6' in the Skeleton className for cleaner styling.

## Test Plan 
- 1. Verify that the Skeleton component renders correctly after the removal of the extra space in the className.
- 2. Check if the styles for the Skeleton component (`w-48` and `h-6`) are applied as expected without any visual or functional issues.
- 3. Test the Skeleton component across different screen sizes to ensure consistent rendering.

## Related Issue
N/A

## Notes
- This change ensures that the styling remains clean and consistent with the coding standards. No additional changes or navigation links are required.
