### PR TITLE
Fix: Corrected SVG attributes to camelCase format

### DIFF
--- a/components/cards/TransactionCard.tsx
+++ b/components/cards/TransactionCard.tsx
@@ -216,9 +216,9 @@ export default function TransactionCard({ classname, data }: { classname?: strin
                 className="rotate-180 transform h-5 w-5"
               >
                 <path
-                  fill-rule="evenodd"
+                  fillRule="evenodd"
                   d="M14.77 12.79a.75.75 0 01-1.06-.02L10 8.832 6.29 12.77a.75.75 0 11-1.08-1.04l4.25-4.5a.75.75 0 011.08 0l4.25 4.5a.75.75 0 01-.02 1.06z"
-                  clip-rule="evenodd"
+                  clipRule="evenodd"
                 ></path>
               </svg>
             </AccordionTrigger>


### PR DESCRIPTION
## Description
This PR resolves invalid DOM property warnings in the `TransactionCard` component by updating SVG attributes to adhere to React/JSX standards. Changes include:

- Updated `fill-rule` to `fillRule`.
- Updated `clip-rule` to `clipRule`.

These changes remove React warnings and ensure compliance with JSX.

## Test Plan 
1. Run the application and navigate to a page using the `TransactionCard` component.
2. Open the browser console and verify that there are no warnings related to `fill-rule` or `clip-rule`.
3. Confirm that the SVG elements render correctly without any issues.
4. After the changes, the browser console no longer displays warnings about `fill-rule` or `clip-rule`.
- See the screenshot below for the resolved state:
![ProtocolExplorerApp Hata Çözüm](https://github.com/user-attachments/assets/bc28a2be-d28c-4d7d-b6a6-8e756ecfcb3c)


## Related Issue
Issue #54

## Notes
No additional changes are required for this fix.